### PR TITLE
Enable Flathub to automatically PR updated source code

### DIFF
--- a/com.github.alexr4535.siglo.json
+++ b/com.github.alexr4535.siglo.json
@@ -34,7 +34,13 @@
                     "type" : "git",
                     "url" : "https://github.com/alexr4535/siglo",
                     "tag" : "v0.8.12",
-                    "commit" : "1e830f913801d1aacc164e8f5f5f42d806ce8da0"
+                    "commit" : "1e830f913801d1aacc164e8f5f5f42d806ce8da0",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 229422,
+                        "stable-only": true,
+                        "tag-template": "v$version"
+                    }
                 }
             ]
         }


### PR DESCRIPTION
This PR adds x-checker-data support for siglo.
This information allows Flathub to automatically detect new versions.
When it does, a Flathub bot will open a PR which updates the source.