### PR TITLE
Use JSON x-checker-data for updating the Flathub version

### DIFF
--- a/com.github.alexr4535.siglo.json
+++ b/com.github.alexr4535.siglo.json
@@ -36,9 +36,11 @@
                     "tag": "v0.8.14",
                     "commit": "7eddd3c12d10cb556b1a311881b459d2e8e6f559",
                     "x-checker-data": {
-                        "type": "git",
-                        "tag-pattern": "^v([\\d.]+)$",
-                        "version-scheme": "semantic"
+                        "type": "json",
+                        "url": "https://api.github.com/repos/alexr4535/siglo/releases/latest",
+                        "tag-query": ".tag_name",
+                        "version-query": ".tag_name | sub(\"^v\"; \"\")",
+                        "timestamp-query": ".published_at"
                     }
                 }
             ]

--- a/com.github.alexr4535.siglo.json
+++ b/com.github.alexr4535.siglo.json
@@ -33,8 +33,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/alexr4535/siglo",
-                    "tag": "v0.8.14",
-                    "commit": "7eddd3c12d10cb556b1a311881b459d2e8e6f559",
+                    "tag": "v0.9.0",
+                    "commit": "65fb60babef8e9ac199e25bf36c630eba5a53d7f",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/alexr4535/siglo/releases/latest",

--- a/com.github.alexr4535.siglo.json
+++ b/com.github.alexr4535.siglo.json
@@ -36,10 +36,9 @@
                     "tag": "v0.8.14",
                     "commit": "7eddd3c12d10cb556b1a311881b459d2e8e6f559",
                     "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 229422,
-                        "stable-only": true,
-                        "tag-template": "v$version"
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$",
+                        "version-scheme": "semantic"
                     }
                 }
             ]

--- a/com.github.alexr4535.siglo.json
+++ b/com.github.alexr4535.siglo.json
@@ -33,8 +33,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/alexr4535/siglo",
-                    "tag": "v0.8.13",
-                    "commit": "19582c2eb680b0cf30b066ca1f09a394e4b07ded",
+                    "tag": "v0.8.14",
+                    "commit": "7eddd3c12d10cb556b1a311881b459d2e8e6f559",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 229422,


### PR DESCRIPTION
Update to the latest version and switch to JSON x-checker-data to get updates on Flathub more quickly. I went ahead and updated to version 0.9.0 of Siglo.